### PR TITLE
Basic implementation of policy and timer

### DIFF
--- a/pkg/reconciler/delivery/delivery.go
+++ b/pkg/reconciler/delivery/delivery.go
@@ -17,6 +17,7 @@ package delivery
 import (
 	"context"
 	"fmt"
+	"time"
 
 	clientset "knative.dev/serving/pkg/client/clientset/versioned"
 	configurationreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/configuration"
@@ -35,19 +36,35 @@ const (
 	KCDNamespace = "knative-serving"
 	// KCDName is the name of this project
 	KCDName = "knative-continuous-delivery"
+	// AnnotationKey is the string used in ObjectMeta.Annotations map for any Route object
+	AnnotationKey = "KCDLastRouteUpdate"
+	// TimeFormat specifies the format used by time.Parse and time.Format
+	TimeFormat = time.ANSIC
 )
 
 // Reconciler implements controller.Reconciler
 type Reconciler struct {
-	client      clientset.Interface
-	routeLister listers.RouteLister 
+	client        clientset.Interface
+	routeLister   listers.RouteLister
+	followup      enqueueFunc
+	timeProvider  timeSnapshotFunc
 }
+
+// private aliases for the types in Reconciler
+type enqueueFunc func(*v1.Configuration, time.Duration)
+type timeSnapshotFunc func() time.Time
 
 // Check that our Reconciler implements ksvcreconciler.Interface
 var _ configurationreconciler.Interface = (*Reconciler)(nil)
+
 var (
-	newPercent int64 = 50
-	oldPercent int64 = 50
+	// we use a global variable for now because we assume for simplicity that all Configurations
+	// use the same policy; in the future, we might want to associate a policy to each Configuration
+	policy Policy = Policy{
+		Mode: "time",
+		Percents: []Stage{{0, nil}, {10, nil}, {50, nil}, {90, nil}},
+		DefaultThreshold: 20,
+	}
 )
 
 // ReconcileKind is a very simple proof-of-concept reconciliation method
@@ -99,20 +116,77 @@ func (c *Reconciler) updateRoute(ctx context.Context, cfg *v1.Configuration) err
 	if err != nil {
 		return err
 	}
-	logger.Info("Applying updated Route object")
-	_, err = c.client.ServingV1().Routes(cfg.Namespace).Update(route)
 
-	return err
+	logger.Info("Applying updated Route object")
+
+	// record the timestamp for the current udpate to the Route object before actually pushing it
+	// this is used later when determining if Route status is up to date
+	if route.Annotations == nil {
+		route.Annotations = make(map[string]string)
+	}
+	route.Annotations[AnnotationKey] = c.timeProvider().Format(TimeFormat)
+	_, err = c.client.ServingV1().Routes(cfg.Namespace).Update(route)
+	if err != nil {
+		return err
+	}
+
+	// when we have latestRevision = true, we know that we don't need to queue future events
+	if *route.Spec.Traffic[0].LatestRevision {
+		logger.Info("Progressive rollout completed!")
+		return nil
+	}
+	t, e := getThreshold(&policy, int(*route.Spec.Traffic[1].Percent))
+	if e != nil {
+		return e
+	}
+	logger.Infof("Queueing event for %v seconds later", t)
+	c.followup(cfg, time.Duration(t) * time.Second)
+
+	return nil
 }
 
 // isRouteStatusUpToDate determines if the current Route status already matches our desired state
 func isRouteStatusUpToDate(route *v1.Route, newRevName string) bool {
-	for idx := range route.Status.Traffic {
-		if route.Status.Traffic[idx].RevisionName == newRevName {
-			return true
+	// the Route status is up to date if:
+	// 1. the new Revision is listed in the status traffic targets, AND
+	// 2. the Route time stamp hasn't expired
+	// OR if:
+	// 3. the new Revision is listed in the status traffic targets, AND
+	// 4. the new Revision already reached 100%
+	nameListed := false
+	for _, t := range route.Status.Traffic {
+		if t.RevisionName == newRevName {
+			nameListed = true
+			break
 		}
 	}
-	return false
+	if !nameListed {
+		return false
+	}
+	if len(route.Status.Traffic) == 1 || *route.Status.Traffic[1].Percent == 100 {
+		return true
+	}
+	// by design, accessing route.Annotations[AnnotationKey] should not cause error
+	previousTime, err := time.Parse(TimeFormat, route.Annotations[AnnotationKey])
+	if err != nil {
+		// we shouldn't be able to reach this because timestamp is always formatted using TimeFormat
+		panic(fmt.Sprintf("failed to parse timestamp for %v", AnnotationKey))
+	}
+	if isTimestampExpired(previousTime, &policy, int(*route.Status.Traffic[1].Percent)) {
+		return false
+	}
+	return true
+}
+
+// isTimestampExpired determines if enough time has elapsed since the last Route update
+func isTimestampExpired(ltt time.Time, p *Policy, cp int) bool {
+	t, e := getThreshold(p, cp)
+	// we can ignore error handling here, because returning true will cause a Route update
+	// modifyRouteSpec will discover the exact same error, and it can report that error more conveniently
+	if e != nil {
+		return true
+	}
+	return !time.Now().Before(ltt.Add(time.Duration(t) * time.Second))
 }
 
 // modifyRouteSpec is a toy function that is designed specifically for the proof-of-concept
@@ -120,32 +194,50 @@ func isRouteStatusUpToDate(route *v1.Route, newRevName string) bool {
 func modifyRouteSpec(route *v1.Route, newRevName string) (*v1.Route, error) {
 	// if there is currently zero traffic targets, then set the Configuration's
 	// latest ready Revision as the default traffic target
-	// if there is currently one traffic target, then split 50% off that target and
+	// if there is currently one traffic target, then split a certain % off that target and
 	// direct it to the new Revision
-	// if there are 2 or more traffic targets, return an error (unexpected use case)
-	if len(route.Status.Traffic) == 0 {
-		route.Spec.Traffic = []v1.TrafficTarget{
-			{
+	// if there are 2 traffic targets, update the percentage split, or report error if the 
+	// new Revision name doesn't match with either target
+	// Note: when there are > 1 traffic targets, it is assumed that they are ordered from oldest to newest
+	newPercent := 100
+	var err error
+
+	if len(route.Status.Traffic) == 1 {
+		if route.Status.Traffic[0].RevisionName == newRevName {
+			return route, nil
+		}
+		newPercent, err = computeNewPercent(&policy, 0)
+		if err != nil {
+			return route, err
+		}
+	} else if len(route.Status.Traffic) == 2 {
+		if route.Status.Traffic[0].RevisionName != newRevName && route.Status.Traffic[1].RevisionName != newRevName {
+			return nil, fmt.Errorf("unsupported use case: current implementation only supports 2 Revisions at once")
+		}
+		newPercent, err = computeNewPercent(&policy, int(*route.Status.Traffic[1].Percent))
+		if err != nil {
+			return route, err
+		}
+	}
+
+	if newPercent == 100 {
+		route.Spec.Traffic = []v1.TrafficTarget{{
 				ConfigurationName: route.Name, // assume namespace/name matches for Route & Config
 				LatestRevision: ptr.Bool(true),
 				Percent: ptr.Int64(100),
-			},
-		}
-	} else if len(route.Status.Traffic) == 1 {
-		route.Spec.Traffic = []v1.TrafficTarget{
-			{
-				RevisionName: newRevName,
-				LatestRevision: ptr.Bool(false),
-				Percent: ptr.Int64(newPercent),
-			},
-			{
-				RevisionName: route.Status.Traffic[0].RevisionName,
-				LatestRevision: ptr.Bool(false),
-				Percent: ptr.Int64(oldPercent),
-			},
-		}
-	} else {
-		return nil, fmt.Errorf("Unsupported use case: current implementation only supports 2 Revisions at once")
+			}}
+		return route, nil
 	}
+	
+	route.Spec.Traffic = []v1.TrafficTarget{{
+			RevisionName: route.Status.Traffic[0].RevisionName,
+			LatestRevision: ptr.Bool(false),
+			Percent: ptr.Int64(int64(100 - newPercent)),
+		},{
+			RevisionName: newRevName,
+			LatestRevision: ptr.Bool(false),
+			Percent: ptr.Int64(int64(newPercent)),
+		}}
+
 	return route, nil
 }

--- a/pkg/reconciler/delivery/policy.go
+++ b/pkg/reconciler/delivery/policy.go
@@ -1,0 +1,80 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package delivery
+
+import (
+	"sort"
+	"fmt"
+)
+
+
+// Policy represents the rollout strategy used to update Route objects
+type Policy struct {
+	// Mode specifies the metric that the policy is based on
+	// Possible values are: "time", "request", "error"
+	Mode string
+
+	// Percents specifies the traffic percentages that the NEW Revision is expected to have
+	// at successive rollout stages; the list of integers must start at 0
+	// all entries must be in the range [0, 100), and must be sorted in increasing order
+	// Technically the final rollout percentage is 100, but this is implicitly understood,
+	// and should NOT be explicitly specified in Percents
+	// In addition to the traffic percentages, each stage can OPTIONALLY specify its own threshold
+	// this gives greater flexibility to policy design
+	// The threshold value for stage N is the value that must be achieved BEFORE moving to stage N+1
+	Percents []Stage
+
+	// DefaultThreshold is the threshold value that is used when a rollout stage doesn't specify
+	// a threshold of its own; this can be useful when the threshold is a constant value across 
+	// all rollout stages, in which case there is no need to copy paste the same value in all entries
+	// The interpretation of DefaultThreshold depends on the value of Mode
+	DefaultThreshold int
+}
+
+// Stage contains information about a progressive rollout stage
+type Stage struct {
+	Percent    int
+	Threshold *int
+}
+
+// computeNewPercent calculates, given a Policy and the current rollout stage,
+// the traffic percentage for the NEW Revision in the next rollout stage
+func computeNewPercent(p *Policy, currentPercent int) (int, error) {
+	i := sort.Search(len(p.Percents), func(i int) bool {
+		return p.Percents[i].Percent >= currentPercent
+	})
+	if i < len(p.Percents) && p.Percents[i].Percent == currentPercent {
+		if i == len(p.Percents) - 1 {
+			return 100, nil
+		}
+		return p.Percents[i + 1].Percent, nil
+	}
+	return 0, fmt.Errorf("invalid percentage for current rollout stage")
+}
+
+// getThreshold returns, given the percentage for a rollout stage, its corresponding threshold value
+// if the threshold value isn't specified, DefaultThreshold is used
+func getThreshold(p *Policy, currentPercent int) (int, error) {
+	i := sort.Search(len(p.Percents), func(i int) bool {
+		return p.Percents[i].Percent >= currentPercent
+	})
+	if i < len(p.Percents) && p.Percents[i].Percent == currentPercent {
+		if p.Percents[i].Threshold != nil {
+			return *p.Percents[i].Threshold, nil
+		}
+		return p.DefaultThreshold, nil
+	}
+	return 0, fmt.Errorf("invalid percentage for current rollout stage")
+}

--- a/pkg/reconciler/delivery/policy_test.go
+++ b/pkg/reconciler/delivery/policy_test.go
@@ -1,0 +1,107 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package delivery
+
+import (
+	"testing"
+)
+
+var (
+	pa = Policy{"time", []Stage{{0, nil}, {1, nil}, {2, nil}, {3, nil}, {4, nil}, {5, nil}, {6, nil}, {7, nil}, {8, nil}, {99, nil}}, 5}
+	pb = Policy{"request", []Stage{{0, nil}, {90, nil}, {91, nil}, {92, nil}, {93, nil}, {94, nil}, {95, nil}, {96, nil}, {97, nil}, {98, nil}, {99, nil}}, 500}
+	pc = Policy{"error", []Stage{{0, nil}, {5, nil}, {20, nil}, {50, nil}, {80, nil}, {95, nil}}, 3}
+	pd = Policy{"time", []Stage{
+		{0, intptr(5)},
+		{4, intptr(10)},
+		{7, intptr(50)},
+		{10, nil},
+	}, 100}
+	p0 = Policy{"time", []Stage{}, 10}
+	pX = Policy{"request", []Stage{{90, nil}, {80, nil}, {70, nil}}, 5}
+)
+
+// knative.dev/pkg/ptr library doesn't have Int, so we need to implement it here
+func intptr(x int) *int {
+	return &x
+}
+
+func TestComputeNewPercent(t *testing.T) {
+	var tests = []struct {
+		name        string
+		policy     *Policy
+		cp          int
+		want        int
+		errExpected bool
+	}{
+		{"PA_present", &pa, 3, 4, false},
+		{"PA_not_present", &pa, 10, 0, true},
+		{"PB_last", &pb, 99, 100, false},
+		{"PB_present", &pb, 0, 90, false},
+		{"PC_last", &pc, 95, 100, false},
+		{"PC_not_present", &pc, 50, 80, false},
+		{"PC_100", &pc, 100, 0, true},
+		{"P0_empty", &p0, 0, 0, true},
+		// the last test should have undefined behavior because policy Percents field must be sorted in increasing order
+		// this test is considered passed as long as the test driver doesn't crash
+		{"PX_unsorted", &pX, 90, -1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ans, e := computeNewPercent(tt.policy, tt.cp)
+			if tt.want == -1 {
+				return
+			}
+			if ans != tt.want {
+				t.Errorf("wrong answer (got %v, want %v)", ans, tt.want)
+			}
+			if (tt.errExpected && e == nil) || (!tt.errExpected && e != nil) {
+				t.Errorf("error output doesn't match")
+			}
+		})
+	}
+}
+
+func TestGetThreshold(t *testing.T) {
+	var tests = []struct {
+		name        string
+		policy     *Policy
+		cp          int
+		want        int
+		errExpected bool
+	}{
+		{"PA_use_default", &pa, 3, 5, false},
+		{"PA_not_present", &pa, 10, 0, true},
+		{"P0_empty", &p0, 0, 0, true},
+		{"PX_unsorted", &pX, 90, -1, true},
+		{"PD_use_threshold", &pd, 7, 50, false},
+		{"PD_last_default", &pd, 10, 100, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ans, e := getThreshold(tt.policy, tt.cp)
+			if tt.want == -1 {
+				return
+			}
+			if ans != tt.want {
+				t.Errorf("wrong answer (got %v, want %v)", ans, tt.want)
+			}
+			if (tt.errExpected && e == nil) || (!tt.errExpected && e != nil) {
+				t.Errorf("error output doesn't match")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR builds upon the proof-of-concept reconciler and implements a hardcoded policy that is used by all Configurations. The policy causes new Revisions to progress from 0, 10, 50, 90, all the way to 100 percent. The part about timestamp comparison is a little hacky, and I'm open to suggestions and alternatives.