### PR TITLE
Some VERY simple unit tests for delivery.go, more coming later

### DIFF
--- a/pkg/reconciler/delivery/delivery.go
+++ b/pkg/reconciler/delivery/delivery.go
@@ -95,7 +95,7 @@ func shouldSkipConfig(cfg *v1.Configuration) bool {
 func configReady(cfg *v1.Configuration) bool {
 	latestReady := cfg.Status.LatestReadyRevisionName
 	latestCreated := cfg.Status.LatestCreatedRevisionName
-	return latestReady == latestCreated
+	return latestReady == latestCreated && latestReady != ""
 }
 
 // updateRoute figures out if the Route object needs any update and updates it as needed

--- a/pkg/reconciler/delivery/delivery_test.go
+++ b/pkg/reconciler/delivery/delivery_test.go
@@ -1,0 +1,66 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package delivery
+
+import (
+	"testing"
+
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	. "knative.dev/serving/pkg/testing/v1"
+)
+
+func TestShouldSkipConfig(t *testing.T) {
+	var tests = []struct {
+		name  string
+		cfg  *v1.Configuration
+		want  bool
+	}{
+		{name: "namespace matches, but name doesn't", cfg: Configuration(KCDNamespace, "random"), want: false},
+		{name: "name matches, but namespace doesn't", cfg: Configuration("random", KCDName), want: false},
+		{name: "namespace and name both match", cfg: Configuration(KCDNamespace, KCDName), want: true},
+		{name: "neither namespace nor name matches", cfg: Configuration("random_namespace", "random_name"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ans := shouldSkipConfig(tt.cfg)
+			if ans != tt.want {
+				t.Errorf("wrong answer (got %v, want %v)", ans, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigReady(t *testing.T) {
+	var tests = []struct {
+		name  string
+		cfg  *v1.Configuration
+		want  bool
+	}{
+		{name: "latestReady and latestCreated don't exist", cfg: Configuration("default", "test"), want: false},
+		{name: "latestCreated present without latestReady", cfg: Configuration("default", "test", WithLatestCreated("not-ready")), want: false},
+		{name: "latestCreated and latestReady are different", cfg: Configuration("default", "test", WithLatestCreated("new"), WithLatestReady("old")), want: false},
+		{name: "latestCreated is also ready", cfg: Configuration("default", "test", WithLatestCreated("ok"), WithLatestReady("ok")), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ans := configReady(tt.cfg)
+			if ans != tt.want {
+				t.Errorf("wrong answer (got %v, want %v)", ans, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/delivery/policy_test.go
+++ b/pkg/reconciler/delivery/policy_test.go
@@ -41,21 +41,21 @@ func TestComputeNewPercent(t *testing.T) {
 	var tests = []struct {
 		name        string
 		policy     *Policy
-		cp          int
+		cp          int  // (c)urrent (p)ercent
 		want        int
 		errExpected bool
 	}{
-		{"PA_present", &pa, 3, 4, false},
-		{"PA_not_present", &pa, 10, 0, true},
-		{"PB_last", &pb, 99, 100, false},
-		{"PB_present", &pb, 0, 90, false},
-		{"PC_last", &pc, 95, 100, false},
-		{"PC_not_present", &pc, 50, 80, false},
-		{"PC_100", &pc, 100, 0, true},
-		{"P0_empty", &p0, 0, 0, true},
+		{name: "policy A, current percent present", policy: &pa, cp: 3, want: 4, errExpected: false},
+		{name: "policy A, current percent not present", policy: &pa, cp: 10, want: 0, errExpected: true},
+		{name: "policy B, input is last stage", policy: &pb, cp: 99, want: 100, errExpected: false},
+		{name: "policy B, current percent present", policy: &pb, cp: 0, want: 90, errExpected: false},
+		{name: "policy C, input is last stage", policy: &pc, cp: 95, want: 100, errExpected: false},
+		{name: "policy C, current percent present", policy: &pc, cp: 50, want: 80, errExpected: false},
+		{name: "policy C, input 100 (error)", policy: &pc, cp: 100, want: 0, errExpected: true},
+		{name: "empty policy (error)", policy: &p0, cp: 0, want: 0, errExpected: true},
 		// the last test should have undefined behavior because policy Percents field must be sorted in increasing order
 		// this test is considered passed as long as the test driver doesn't crash
-		{"PX_unsorted", &pX, 90, -1, true},
+		{name: "unsorted policy (undefined)", policy: &pX, cp: 90, want: -1, errExpected: true},
 	}
 
 	for _, tt := range tests {
@@ -82,12 +82,12 @@ func TestGetThreshold(t *testing.T) {
 		want        int
 		errExpected bool
 	}{
-		{"PA_use_default", &pa, 3, 5, false},
-		{"PA_not_present", &pa, 10, 0, true},
-		{"P0_empty", &p0, 0, 0, true},
-		{"PX_unsorted", &pX, 90, -1, true},
-		{"PD_use_threshold", &pd, 7, 50, false},
-		{"PD_last_default", &pd, 10, 100, false},
+		{name: "policy A, return default threshold", policy: &pa, cp: 3, want: 5, errExpected: false},
+		{name: "policy A, current percent not present", policy: &pa, cp: 10, want: 0, errExpected: true},
+		{name: "empty policy (error)", policy: &p0, cp: 0, want: 0, errExpected: true},
+		{name: "unsorted policy (undefined)", policy: &pX, cp: 90, want: -1, errExpected: true},
+		{name: "policy D, stage specifies own threshold", policy: &pd, cp: 7, want: 50, errExpected: false},
+		{name: "policy D, last stage with default threshold", policy: &pd, cp: 10, want: 100, errExpected: false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adds very simple unit tests for 2 of the easier-to-test functions in delivery.go; fixed a small bug where `configReady` should return false instead of true when everything is absent.