### PR TITLE
Use PostConditions to test event queue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/googleinterns/knative-continuous-delivery
 go 1.14
 
 require (
+	github.com/google/go-cmp v0.5.0
 	k8s.io/apimachinery v0.18.5
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 	knative.dev/pkg v0.0.0-20200708171447-5358179e7499

--- a/pkg/reconciler/testing/factory.go
+++ b/pkg/reconciler/testing/factory.go
@@ -44,7 +44,7 @@ const (
 )
 
 // Ctor functions create a k8s controller with given params.
-type Ctor func(context.Context, *Listers, configmap.Watcher) controller.Reconciler
+type Ctor func(context.Context, *Listers, configmap.Watcher, *rtesting.TableRow) controller.Reconciler
 
 // MakeFactory creates a reconciler factory with fake clients and controller created by `ctor`.
 func MakeFactory(ctor Ctor) rtesting.Factory {
@@ -89,7 +89,7 @@ func MakeFactory(ctor Ctor) rtesting.Factory {
 		rtesting.PrependGenerateNameReactor(&client.Fake)
 
 		// Set up our Controller from the fakes.
-		c := ctor(ctx, &ls, configmap.NewStaticWatcher())
+		c := ctor(ctx, &ls, configmap.NewStaticWatcher(), r)
 		// Update the context with the stuff we decorated it with.
 		r.Ctx = ctx
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -89,6 +89,7 @@ github.com/golang/protobuf/ptypes/struct
 github.com/golang/protobuf/ptypes/timestamp
 github.com/golang/protobuf/ptypes/wrappers
 # github.com/google/go-cmp v0.5.0
+## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/cmpopts
 github.com/google/go-cmp/cmp/internal/diff


### PR DESCRIPTION
Use PostConditions in TableRow to test whether or not an event has been enqueued properly during reconciliation.