### PR TITLE
Minor refactoring; unit tests for delivery.go & modify.go

### DIFF
--- a/pkg/reconciler/delivery/delivery_test.go
+++ b/pkg/reconciler/delivery/delivery_test.go
@@ -16,9 +16,15 @@ package delivery
 
 import (
 	"testing"
+	"math"
+	"time"
 
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	. "knative.dev/serving/pkg/testing/v1"
+	"knative.dev/pkg/ptr"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestShouldSkipConfig(t *testing.T) {
@@ -62,5 +68,189 @@ func TestConfigReady(t *testing.T) {
 				t.Errorf("wrong answer (got %v, want %v)", ans, tt.want)
 			}
 		})
+	}
+}
+
+func TestMin(t *testing.T) {
+	var tests = []struct{
+		name  string
+		items []int
+		want  int
+	}{
+		{name: "return the only item when only 1 item is present", items: []int{5}, want: 5},
+		{name: "many diverse items", items: []int{9,10,-2,7,-5,0,3,-13,8}, want:-13},
+		{name: "return MAX INT when it is the smallest", items: []int{math.MaxInt32, math.MaxInt32}, want: math.MaxInt32},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ans := min(tt.items...)
+			if ans != tt.want {
+				t.Errorf("wrong answer (got %v, want %v)", ans, tt.want)
+			}
+		})
+	}
+}
+
+func TestTimeTillNextEvent(t *testing.T) {
+	var tests = []struct{
+		name        string
+		route      *v1.Route
+		revMap      map[string]*v1.Revision
+		policy     *Policy
+		want        time.Duration
+		errExpected bool
+	}{{
+		name: "empty route returns MAX time duration",
+		route: Route("default", "test"),
+		revMap: nil,
+		policy: &pa,
+		want: time.Duration(math.MaxInt32) * time.Second,
+		errExpected: false,
+	}, {
+		name: "route status has unknown target Revision (error)",
+		route: Route("default", "test", withTraffic("spec", pair{"unknown-1", 50}, pair{"unknown-2", 50})),
+		revMap: map[string]*v1.Revision{
+			"R1": Revision("default", "R1"),
+			"R2": Revision("default", "R2"),
+		},
+		policy: &pa,
+		want: 0,
+		errExpected: true,
+	}, {
+		name: "policy A, very old + redundant Revisions",
+		route: Route("default", "test", withTraffic("spec", pair{"R1", 85}, pair{"R2", 8}, pair{"R3", 7})),
+		revMap: map[string]*v1.Revision{
+			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-500 * time.Second))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-450 * time.Second))),
+			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-400 * time.Second))),
+			"R4": Revision("default", "R4", WithCreationTimestamp(time.Now().Add(-350 * time.Second))),
+			"R5": Revision("default", "R5", WithCreationTimestamp(time.Now().Add(-300 * time.Second))),
+		},
+		policy: &pa,
+		want: time.Duration(math.MaxInt32) * time.Second,
+		errExpected: false,
+	}, {
+		name: "policy A, all Revisions in progress",
+		route: Route("default", "test", withTraffic("spec", pair{"R1", 85}, pair{"R2", 8}, pair{"R3", 7})),
+		revMap: map[string]*v1.Revision{
+			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-24500 * time.Millisecond))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-18 * time.Second))),
+			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-12 * time.Second))),
+		},
+		policy: &pa,
+		want: time.Second,
+		errExpected: false,
+	}, {
+		name: "policy A, at least one Revision is very old",
+		route: Route("default", "test", withTraffic("spec", pair{"R1", 85}, pair{"R2", 8}, pair{"R3", 7})),
+		revMap: map[string]*v1.Revision{
+			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-500 * time.Second))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-18500 * time.Millisecond))),
+			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-12 * time.Second))),
+		},
+		policy: &pa,
+		want: 2 * time.Second,
+		errExpected: false,
+	}}
+
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ans, e := timeTillNextEvent(tt.route, tt.revMap, tt.policy)
+			if ans != tt.want {
+				t.Errorf("wrong answer (got %v, want %v)", ans, tt.want)
+			}
+			if (tt.errExpected && e == nil) || (!tt.errExpected && e != nil) {
+				t.Errorf("error output doesn't match")
+			}
+		})
+	}
+}
+
+func TestModifyRouteSpec(t *testing.T) {
+	var tests = []struct{
+		name        string
+		route      *v1.Route
+		revMap      map[string]*v1.Revision
+		newRevName  string
+		policy     *Policy
+		want       *v1.Route
+		errExpected bool
+	}{{
+		name: "newRevName is the only thing in the pool",
+		route: Route("default", "test"),
+		revMap: map[string]*v1.Revision{
+			"new": Revision("default", "new", withOwnerReferences([]metav1.OwnerReference{{
+				Kind: "Configuration",
+				Name: "new",
+			}})),
+		},
+		newRevName: "new",
+		policy: &pa,
+		want: Route("default", "test", WithSpecTraffic(v1.TrafficTarget{
+			ConfigurationName: "new",
+			LatestRevision: ptr.Bool(true),
+			Percent: ptr.Int64(100),
+		})),
+		errExpected: false,
+	}, {
+		name: "newRevName is new, adds to an existing pool",
+		route: Route("default", "test", withTraffic("status", pair{"R1", 95}, pair{"R2", 5})),
+		revMap: map[string]*v1.Revision{
+			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-10000 * time.Second))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-21 * time.Second))),
+			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now())),
+		},
+		newRevName: "R3",
+		policy: &pa,
+		want: Route("default", "test", withTraffic("status", pair{"R1", 95}, pair{"R2", 5}),
+			withTraffic("spec", pair{"R1", 94}, pair{"R2", 5}, pair{"R3", 1})),
+		errExpected: false,
+	}, {
+		name: "promotion, but pool size doesn't change",
+		route: Route("default", "test", withTraffic("status", pair{"R1", 94}, pair{"R2", 5}, pair{"R3", 1})),
+		revMap: map[string]*v1.Revision{
+			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-10000 * time.Second))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-26 * time.Second))),
+			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-2 * time.Second))),
+		},
+		newRevName: "R3",
+		policy: &pa,
+		want: Route("default", "test", withTraffic("status", pair{"R1", 94}, pair{"R2", 5}, pair{"R3", 1}),
+			withTraffic("spec", pair{"R1", 93}, pair{"R2", 6}, pair{"R3", 1})),
+		errExpected: false,
+	}, {
+		name: "promotion, and pool size shrinks",
+		route: Route("default", "test", withTraffic("status", pair{"R1", 85}, pair{"R2", 8}, pair{"R3", 7})),
+		revMap: map[string]*v1.Revision{
+			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-10000 * time.Second))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-41 * time.Second))),
+			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-33 * time.Second))),
+		},
+		newRevName: "R3",
+		policy: &pa,
+		want: Route("default", "test", withTraffic("status", pair{"R1", 85}, pair{"R2", 8}, pair{"R3", 7}),
+			withTraffic("spec", pair{"R2", 93}, pair{"R3", 7})),
+		errExpected: false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ans, e := modifyRouteSpec(tt.route, tt.revMap, tt.newRevName, tt.policy)
+			if diff := cmp.Diff(tt.want, ans); diff != "" {
+				t.Errorf("Route object is incorrect (-want, +got): %s", diff)
+			}
+			if (tt.errExpected && e == nil) || (!tt.errExpected && e != nil) {
+				t.Errorf("error output doesn't match")
+			}
+		})
+	}
+}
+
+// withOwnerReferences sets the OwnerReferences of a Revision
+func withOwnerReferences(references []metav1.OwnerReference) RevisionOption {
+	return func(rev *v1.Revision) {
+		rev.ObjectMeta.SetOwnerReferences(references)
 	}
 }

--- a/pkg/reconciler/delivery/table_test.go
+++ b/pkg/reconciler/delivery/table_test.go
@@ -91,6 +91,21 @@ func Configuration(namespace, name string, co ...ConfigOption) *v1.Configuration
 	return c
 }
 
+// Revision creates a revision with RevisionOptions
+func Revision(namespace, name string, ro ...RevisionOption) *v1.Revision {
+	r := &v1.Revision{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+	for _, opt := range ro {
+		opt(r)
+	}
+	r.SetDefaults(context.Background())
+	return r
+}
+
 // this type is simply a convenient alias, see withTraffic funtion below for its purpose
 type pair struct {
 	name  string


### PR DESCRIPTION
A few lines in `delivery.go` and `modify.go` are refactored to improve performance and accommodate unit testing.

Added unit tests for `min`, `timeTillNextEvent` and `modifyRouteSpec`.