### PR TITLE
Table tests; one more unit test for modify.go

### DIFF
--- a/pkg/reconciler/delivery/controller.go
+++ b/pkg/reconciler/delivery/controller.go
@@ -27,8 +27,8 @@ import (
 	routeinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/route"
 	configurationreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/configuration"
 
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	servingreconciler "knative.dev/serving/pkg/reconciler"
 )
@@ -45,9 +45,9 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	revisionInformer := revisioninformer.Get(ctx)
 
 	c := &Reconciler{
-		client:              servingclient.Get(ctx),
-		routeLister:         routeInformer.Lister(),
-		revisionLister:      revisionInformer.Lister(),
+		client:         servingclient.Get(ctx),
+		routeLister:    routeInformer.Lister(),
+		revisionLister: revisionInformer.Lister(),
 	}
 	impl := configurationreconciler.NewImpl(ctx, c)
 	// a little hack that allows the reconciler to queue an event for future processing by itself

--- a/pkg/reconciler/delivery/delivery_test.go
+++ b/pkg/reconciler/delivery/delivery_test.go
@@ -15,23 +15,23 @@
 package delivery
 
 import (
-	"testing"
 	"math"
+	"testing"
 	"time"
 
+	"knative.dev/pkg/ptr"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	. "knative.dev/serving/pkg/testing/v1"
-	"knative.dev/pkg/ptr"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestShouldSkipConfig(t *testing.T) {
 	var tests = []struct {
-		name  string
+		name string
 		cfg  *v1.Configuration
-		want  bool
+		want bool
 	}{
 		{name: "namespace matches, but name doesn't", cfg: Configuration(KCDNamespace, "random"), want: false},
 		{name: "name matches, but namespace doesn't", cfg: Configuration("random", KCDName), want: false},
@@ -51,9 +51,9 @@ func TestShouldSkipConfig(t *testing.T) {
 
 func TestConfigReady(t *testing.T) {
 	var tests = []struct {
-		name  string
+		name string
 		cfg  *v1.Configuration
-		want  bool
+		want bool
 	}{
 		{name: "latestReady and latestCreated don't exist", cfg: Configuration("default", "test"), want: false},
 		{name: "latestCreated present without latestReady", cfg: Configuration("default", "test", WithLatestCreated("not-ready")), want: false},
@@ -72,13 +72,13 @@ func TestConfigReady(t *testing.T) {
 }
 
 func TestMin(t *testing.T) {
-	var tests = []struct{
+	var tests = []struct {
 		name  string
 		items []int
 		want  int
 	}{
 		{name: "return the only item when only 1 item is present", items: []int{5}, want: 5},
-		{name: "many diverse items", items: []int{9,10,-2,7,-5,0,3,-13,8}, want:-13},
+		{name: "many diverse items", items: []int{9, 10, -2, 7, -5, 0, 3, -13, 8}, want: -13},
 		{name: "return MAX INT when it is the smallest", items: []int{math.MaxInt32, math.MaxInt32}, want: math.MaxInt32},
 	}
 
@@ -93,67 +93,66 @@ func TestMin(t *testing.T) {
 }
 
 func TestTimeTillNextEvent(t *testing.T) {
-	var tests = []struct{
+	var tests = []struct {
 		name        string
-		route      *v1.Route
+		route       *v1.Route
 		revMap      map[string]*v1.Revision
-		policy     *Policy
+		policy      *Policy
 		want        time.Duration
 		errExpected bool
 	}{{
-		name: "empty route returns MAX time duration",
-		route: Route("default", "test"),
-		revMap: nil,
-		policy: &pa,
-		want: time.Duration(math.MaxInt32) * time.Second,
+		name:        "empty route returns MAX time duration",
+		route:       Route("default", "test"),
+		revMap:      nil,
+		policy:      &pa,
+		want:        time.Duration(math.MaxInt32) * time.Second,
 		errExpected: false,
 	}, {
-		name: "route status has unknown target Revision (error)",
+		name:  "route status has unknown target Revision (error)",
 		route: Route("default", "test", withTraffic("spec", pair{"unknown-1", 50}, pair{"unknown-2", 50})),
 		revMap: map[string]*v1.Revision{
 			"R1": Revision("default", "R1"),
 			"R2": Revision("default", "R2"),
 		},
-		policy: &pa,
-		want: 0,
+		policy:      &pa,
+		want:        0,
 		errExpected: true,
 	}, {
-		name: "policy A, very old + redundant Revisions",
+		name:  "policy A, very old + redundant Revisions",
 		route: Route("default", "test", withTraffic("spec", pair{"R1", 85}, pair{"R2", 8}, pair{"R3", 7})),
 		revMap: map[string]*v1.Revision{
-			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-500 * time.Second))),
-			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-450 * time.Second))),
-			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-400 * time.Second))),
-			"R4": Revision("default", "R4", WithCreationTimestamp(time.Now().Add(-350 * time.Second))),
-			"R5": Revision("default", "R5", WithCreationTimestamp(time.Now().Add(-300 * time.Second))),
+			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-500*time.Second))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-450*time.Second))),
+			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-400*time.Second))),
+			"R4": Revision("default", "R4", WithCreationTimestamp(time.Now().Add(-350*time.Second))),
+			"R5": Revision("default", "R5", WithCreationTimestamp(time.Now().Add(-300*time.Second))),
 		},
-		policy: &pa,
-		want: time.Duration(math.MaxInt32) * time.Second,
+		policy:      &pa,
+		want:        time.Duration(math.MaxInt32) * time.Second,
 		errExpected: false,
 	}, {
-		name: "policy A, all Revisions in progress",
+		name:  "policy A, all Revisions in progress",
 		route: Route("default", "test", withTraffic("spec", pair{"R1", 85}, pair{"R2", 8}, pair{"R3", 7})),
 		revMap: map[string]*v1.Revision{
-			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-24500 * time.Millisecond))),
-			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-18 * time.Second))),
-			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-12 * time.Second))),
+			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-24500*time.Millisecond))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-18*time.Second))),
+			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-12*time.Second))),
 		},
-		policy: &pa,
-		want: time.Second,
+		policy:      &pa,
+		want:        time.Second,
 		errExpected: false,
 	}, {
-		name: "policy A, at least one Revision is very old",
+		name:  "policy A, at least one Revision is very old",
 		route: Route("default", "test", withTraffic("spec", pair{"R1", 85}, pair{"R2", 8}, pair{"R3", 7})),
 		revMap: map[string]*v1.Revision{
-			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-500 * time.Second))),
-			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-18500 * time.Millisecond))),
-			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-12 * time.Second))),
+			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-500*time.Second))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-18500*time.Millisecond))),
+			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-12*time.Second))),
 		},
-		policy: &pa,
-		want: 2 * time.Second,
+		policy:      &pa,
+		want:        2 * time.Second,
 		errExpected: false,
 	}}
-
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -169,16 +168,16 @@ func TestTimeTillNextEvent(t *testing.T) {
 }
 
 func TestModifyRouteSpec(t *testing.T) {
-	var tests = []struct{
+	var tests = []struct {
 		name        string
-		route      *v1.Route
+		route       *v1.Route
 		revMap      map[string]*v1.Revision
 		newRevName  string
-		policy     *Policy
-		want       *v1.Route
+		policy      *Policy
+		want        *v1.Route
 		errExpected bool
 	}{{
-		name: "newRevName is the only thing in the pool",
+		name:  "newRevName is the only thing in the pool",
 		route: Route("default", "test"),
 		revMap: map[string]*v1.Revision{
 			"new": Revision("default", "new", withOwnerReferences([]metav1.OwnerReference{{
@@ -187,51 +186,65 @@ func TestModifyRouteSpec(t *testing.T) {
 			}})),
 		},
 		newRevName: "new",
-		policy: &pa,
+		policy:     &pa,
 		want: Route("default", "test", WithSpecTraffic(v1.TrafficTarget{
 			ConfigurationName: "new",
-			LatestRevision: ptr.Bool(true),
-			Percent: ptr.Int64(100),
+			LatestRevision:    ptr.Bool(true),
+			Percent:           ptr.Int64(100),
 		})),
 		errExpected: false,
 	}, {
-		name: "newRevName is new, adds to an existing pool",
+		name:  "newRevName is new, adds to an existing pool",
 		route: Route("default", "test", withTraffic("status", pair{"R1", 95}, pair{"R2", 5})),
 		revMap: map[string]*v1.Revision{
-			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-10000 * time.Second))),
-			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-21 * time.Second))),
+			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-10000*time.Second))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-21*time.Second))),
 			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now())),
 		},
 		newRevName: "R3",
-		policy: &pa,
+		policy:     &pa,
 		want: Route("default", "test", withTraffic("status", pair{"R1", 95}, pair{"R2", 5}),
 			withTraffic("spec", pair{"R1", 94}, pair{"R2", 5}, pair{"R3", 1})),
 		errExpected: false,
 	}, {
-		name: "promotion, but pool size doesn't change",
+		name:  "promotion, but pool size doesn't change",
 		route: Route("default", "test", withTraffic("status", pair{"R1", 94}, pair{"R2", 5}, pair{"R3", 1})),
 		revMap: map[string]*v1.Revision{
-			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-10000 * time.Second))),
-			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-26 * time.Second))),
-			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-2 * time.Second))),
+			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-10000*time.Second))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-26*time.Second))),
+			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-2*time.Second))),
 		},
 		newRevName: "R3",
-		policy: &pa,
+		policy:     &pa,
 		want: Route("default", "test", withTraffic("status", pair{"R1", 94}, pair{"R2", 5}, pair{"R3", 1}),
 			withTraffic("spec", pair{"R1", 93}, pair{"R2", 6}, pair{"R3", 1})),
 		errExpected: false,
 	}, {
-		name: "promotion, and pool size shrinks",
+		name:  "promotion, and pool size shrinks",
 		route: Route("default", "test", withTraffic("status", pair{"R1", 85}, pair{"R2", 8}, pair{"R3", 7})),
 		revMap: map[string]*v1.Revision{
-			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-10000 * time.Second))),
-			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-41 * time.Second))),
-			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-33 * time.Second))),
+			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-10000*time.Second))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-41*time.Second))),
+			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-33*time.Second))),
 		},
 		newRevName: "R3",
-		policy: &pa,
+		policy:     &pa,
 		want: Route("default", "test", withTraffic("status", pair{"R1", 85}, pair{"R2", 8}, pair{"R3", 7}),
 			withTraffic("spec", pair{"R2", 93}, pair{"R3", 7})),
+		errExpected: false,
+	}, {
+		name:  "oldest revision always ignores progression/timer",
+		route: Route("default", "test", withTraffic("status", pair{"R1", 99}, pair{"R2", 1})),
+		revMap: map[string]*v1.Revision{
+			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-125*time.Second)),
+				WithRevisionLabel(RevisionGenerationKey, "1")),
+			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-61500*time.Millisecond)),
+				WithRevisionLabel(RevisionGenerationKey, "2")),
+		},
+		newRevName: "R2",
+		policy:     &policy,
+		want: Route("default", "test", withTraffic("status", pair{"R1", 99}, pair{"R2", 1}),
+			withTraffic("spec", pair{"R1", 90}, pair{"R2", 10})),
 		errExpected: false,
 	}}
 

--- a/pkg/reconciler/delivery/policy.go
+++ b/pkg/reconciler/delivery/policy.go
@@ -15,12 +15,11 @@
 package delivery
 
 import (
-	"sort"
 	"fmt"
-	"time"
 	"math"
+	"sort"
+	"time"
 )
-
 
 // Policy represents the rollout strategy used to update Route objects
 type Policy struct {
@@ -39,7 +38,7 @@ type Policy struct {
 	Stages []Stage
 
 	// DefaultThreshold is the threshold value that is used when a rollout stage doesn't specify
-	// a threshold of its own; this can be useful when the threshold is a constant value across 
+	// a threshold of its own; this can be useful when the threshold is a constant value across
 	// all rollout stages, in which case there is no need to copy paste the same value in all entries
 	// The interpretation of DefaultThreshold depends on the value of Mode
 	DefaultThreshold int
@@ -47,7 +46,7 @@ type Policy struct {
 
 // Stage contains information about a progressive rollout stage
 type Stage struct {
-	Percent    int
+	Percent   int
 	Threshold *int
 }
 
@@ -58,10 +57,10 @@ func computeNewPercent(p *Policy, currentPercent int) (int, error) {
 		return p.Stages[i].Percent >= currentPercent
 	})
 	if i < len(p.Stages) && p.Stages[i].Percent == currentPercent {
-		if i == len(p.Stages) - 1 {
+		if i == len(p.Stages)-1 {
 			return 100, nil
 		}
-		return p.Stages[i + 1].Percent, nil
+		return p.Stages[i+1].Percent, nil
 	}
 	return 0, fmt.Errorf("invalid percentage for current rollout stage")
 }
@@ -119,7 +118,7 @@ func metricTillNextStage(p *Policy, elapsed time.Duration) int {
 		}
 		metricCumulative += extra
 		if float64(metricCumulative) > metric {
-			return int(float64(metricCumulative) - metric) + 1 // +1 deals with float truncating
+			return int(float64(metricCumulative)-metric) + 1 // +1 deals with float truncating
 		}
 	}
 	return math.MaxInt32

--- a/pkg/reconciler/delivery/policy_test.go
+++ b/pkg/reconciler/delivery/policy_test.go
@@ -15,9 +15,9 @@
 package delivery
 
 import (
+	"math"
 	"testing"
 	"time"
-	"math"
 )
 
 var (
@@ -42,8 +42,8 @@ func intptr(x int) *int {
 func TestComputeNewPercent(t *testing.T) {
 	var tests = []struct {
 		name        string
-		policy     *Policy
-		cp          int  // (c)urrent (p)ercent
+		policy      *Policy
+		cp          int // (c)urrent (p)ercent
 		want        int
 		errExpected bool
 	}{
@@ -79,7 +79,7 @@ func TestComputeNewPercent(t *testing.T) {
 func TestGetThreshold(t *testing.T) {
 	var tests = []struct {
 		name        string
-		policy     *Policy
+		policy      *Policy
 		cp          int
 		want        int
 		errExpected bool
@@ -111,7 +111,7 @@ func TestGetThreshold(t *testing.T) {
 func TestComputeNewPercentExplicit(t *testing.T) {
 	var tests = []struct {
 		name    string
-		policy *Policy
+		policy  *Policy
 		elapsed time.Duration
 		want    int
 	}{
@@ -137,7 +137,7 @@ func TestComputeNewPercentExplicit(t *testing.T) {
 func TestMetricTillNextStage(t *testing.T) {
 	var tests = []struct {
 		name    string
-		policy *Policy
+		policy  *Policy
 		elapsed time.Duration
 		want    int
 	}{

--- a/pkg/reconciler/delivery/table_test.go
+++ b/pkg/reconciler/delivery/table_test.go
@@ -16,14 +16,13 @@ package delivery
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
-	"fmt"
-
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	// clientgotesting "k8s.io/client-go/testing"
+	clientgotesting "k8s.io/client-go/testing"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -51,21 +50,74 @@ func TestReconcile(t *testing.T) {
 			Route("default", "test1", WithConfigTarget("test1"), WithRouteGeneration(1)),
 			Configuration(KCDNamespace, KCDName),
 		},
+		PostConditions: []func(*testing.T, *TableRow){
+			assertNoEventQueued("default/test1"),
+		},
 	}, {
 		Name: "does nothing when latest created is not ready",
 		Key:  "default/test2",
 		Objects: []runtime.Object{
 			Route("default", "test2", WithConfigTarget("test2"), WithRouteGeneration(1)),
-			Configuration("default", "test2", WithLatestCreated("rev-1")),
+			Configuration("default", "test2", WithLatestCreated("rev-2"), WithLatestReady("rev-1")),
+		},
+		PostConditions: []func(*testing.T, *TableRow){
+			assertEventQueued("default/test2", 5*time.Second),
+		},
+	}, {
+		Name: "degenerate to simple logic with only 2 Revisions",
+		Key:  "default/test3",
+		Objects: []runtime.Object{
+			Route("default", "test3", withTraffic("status", pair{"R1", 99}, pair{"R2", 1})),
+			Configuration("default", "test3", WithLatestCreated("R2"), WithLatestReady("R2")),
+			Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-125*time.Second)),
+				WithRevisionLabel(RevisionGenerationKey, "1")),
+			Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-61100*time.Millisecond)),
+				WithRevisionLabel(RevisionGenerationKey, "2")),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: Route("default", "test3", withTraffic("status", pair{"R1", 99}, pair{"R2", 1}),
+				withTraffic("spec", pair{"R1", 90}, pair{"R2", 10})),
+		}},
+		PostConditions: []func(*testing.T, *TableRow){
+			assertEventQueued("default/test3", 59*time.Second),
+		},
+	}, {
+		Name: "many Revisions squeeze out the oldest one",
+		Key:  "default/test4",
+		Objects: []runtime.Object{
+			Route("default", "test4", withTraffic("status", pair{"R1", 58}, pair{"R2", 10}, pair{"R3", 10}, pair{"R4", 10}, pair{"R5", 10}, pair{"R6", 1}, pair{"R7", 1})),
+			Configuration("default", "test4", WithLatestCreated("R7"), WithLatestReady("R7")),
+			Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-125*time.Second)),
+				WithRevisionLabel(RevisionGenerationKey, "1")),
+			Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-121500*time.Millisecond)),
+				WithRevisionLabel(RevisionGenerationKey, "2")),
+			Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-121500*time.Millisecond)),
+				WithRevisionLabel(RevisionGenerationKey, "3")),
+			Revision("default", "R4", WithCreationTimestamp(time.Now().Add(-121500*time.Millisecond)),
+				WithRevisionLabel(RevisionGenerationKey, "4")),
+			Revision("default", "R5", WithCreationTimestamp(time.Now().Add(-121500*time.Millisecond)),
+				WithRevisionLabel(RevisionGenerationKey, "5")),
+			Revision("default", "R6", WithCreationTimestamp(time.Now().Add(-62100*time.Millisecond)),
+				WithRevisionLabel(RevisionGenerationKey, "6")),
+			Revision("default", "R7", WithCreationTimestamp(time.Now().Add(-61500*time.Millisecond)),
+				WithRevisionLabel(RevisionGenerationKey, "7")),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: Route("default", "test4", withTraffic("status", pair{"R1", 58}, pair{"R2", 10}, pair{"R3", 10}, pair{"R4", 10}, pair{"R5", 10}, pair{"R6", 1}, pair{"R7", 1}),
+				withTraffic("spec", pair{"R2", 20}, pair{"R3", 20}, pair{"R4", 20}, pair{"R5", 20}, pair{"R6", 10}, pair{"R7", 10})),
+		}},
+		PostConditions: []func(*testing.T, *TableRow){
+			assertEventQueued("default/test4", 58*time.Second),
 		},
 	}}
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher, tr *TableRow) controller.Reconciler {
 		tr.OtherTestData = make(map[string]interface{})
 		r := &Reconciler{
-			client:      servingclient.Get(ctx),
-			routeLister: listers.GetRouteLister(),
+			client:         servingclient.Get(ctx),
+			routeLister:    listers.GetRouteLister(),
+			revisionLister: listers.GetRevisionLister(),
 			// note that we manually, systematically assigned unique namespace/name strings to each test Configuration
-			// we use those strings for each test 
+			// we use those strings for each test
 			followup: func(cfg *v1.Configuration, t time.Duration) {
 				key := cfg.GetNamespace() + "/" + cfg.GetName()
 				tr.OtherTestData[key] = fmt.Sprintf("%v", t)
@@ -117,9 +169,9 @@ func withTraffic(field string, nameValuePairs ...pair) RouteOption {
 	tt := make([]v1.TrafficTarget, len(nameValuePairs))
 	for i, pair := range nameValuePairs {
 		tt[i] = v1.TrafficTarget{
-			RevisionName: pair.name,
+			RevisionName:   pair.name,
 			LatestRevision: ptr.Bool(false),
-			Percent: ptr.Int64(pair.value),
+			Percent:        ptr.Int64(pair.value),
 		}
 	}
 	if len(nameValuePairs) == 1 {
@@ -145,7 +197,7 @@ func assertEventQueued(key string, want time.Duration) func(*testing.T, *TableRo
 			t.Errorf("expected event to be enqueued, but none found")
 			return
 		}
-		if diff := cmp.Diff(got, fmt.Sprintf("%v", want)); diff != "" {
+		if diff := cmp.Diff(fmt.Sprintf("%v", want), got); diff != "" {
 			t.Errorf("event is not correctly enqueued (-want, +got) %v", diff)
 		}
 	}

--- a/pkg/reconciler/testing/listers.go
+++ b/pkg/reconciler/testing/listers.go
@@ -86,3 +86,8 @@ func (l *Listers) GetRouteLister() servinglisters.RouteLister {
 func (l *Listers) GetConfigurationLister() servinglisters.ConfigurationLister {
 	return servinglisters.NewConfigurationLister(l.IndexerFor(&v1.Configuration{}))
 }
+
+// GetRevisionLister returns the RevisionLister
+func (l *Listers) GetRevisionLister() servinglisters.RevisionLister {
+	return servinglisters.NewRevisionLister(l.IndexerFor(&v1.Revision{}))
+}


### PR DESCRIPTION
Rewrote table tests. Added 1 unit test for `modifyRouteSpec` to cover the implicit assumption that the oldest revision should ignore progression/timer in all circumstances.