### PR TITLE
Minor refactoring & fixes

### DIFF
--- a/pkg/reconciler/delivery/controller.go
+++ b/pkg/reconciler/delivery/controller.go
@@ -28,6 +28,7 @@ import (
 	configurationreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/configuration"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/client-go/tools/cache"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	servingreconciler "knative.dev/serving/pkg/reconciler"
@@ -48,6 +49,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		client:         servingclient.Get(ctx),
 		routeLister:    routeInformer.Lister(),
 		revisionLister: revisionInformer.Lister(),
+		clock:          clock.RealClock{},
 	}
 	impl := configurationreconciler.NewImpl(ctx, c)
 	// a little hack that allows the reconciler to queue an event for future processing by itself

--- a/pkg/reconciler/delivery/delivery_test.go
+++ b/pkg/reconciler/delivery/delivery_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/clock"
 	"knative.dev/pkg/ptr"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	. "knative.dev/serving/pkg/testing/v1"
@@ -93,11 +94,14 @@ func TestMin(t *testing.T) {
 }
 
 func TestTimeTillNextEvent(t *testing.T) {
+	var now = time.Now()
+	var timer = clock.NewFakeClock(now)
 	var tests = []struct {
 		name        string
 		route       *v1.Route
 		revMap      map[string]*v1.Revision
 		policy      *Policy
+		clock       clock.Clock
 		want        time.Duration
 		errExpected bool
 	}{{
@@ -105,6 +109,7 @@ func TestTimeTillNextEvent(t *testing.T) {
 		route:       Route("default", "test"),
 		revMap:      nil,
 		policy:      &pa,
+		clock:       timer,
 		want:        time.Duration(math.MaxInt32) * time.Second,
 		errExpected: false,
 	}, {
@@ -115,48 +120,52 @@ func TestTimeTillNextEvent(t *testing.T) {
 			"R2": Revision("default", "R2"),
 		},
 		policy:      &pa,
+		clock:       timer,
 		want:        0,
 		errExpected: true,
 	}, {
 		name:  "policy A, very old + redundant Revisions",
 		route: Route("default", "test", withTraffic("spec", pair{"R1", 85}, pair{"R2", 8}, pair{"R3", 7})),
 		revMap: map[string]*v1.Revision{
-			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-500*time.Second))),
-			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-450*time.Second))),
-			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-400*time.Second))),
-			"R4": Revision("default", "R4", WithCreationTimestamp(time.Now().Add(-350*time.Second))),
-			"R5": Revision("default", "R5", WithCreationTimestamp(time.Now().Add(-300*time.Second))),
+			"R1": Revision("default", "R1", WithCreationTimestamp(now.Add(-500*time.Second))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(now.Add(-450*time.Second))),
+			"R3": Revision("default", "R3", WithCreationTimestamp(now.Add(-400*time.Second))),
+			"R4": Revision("default", "R4", WithCreationTimestamp(now.Add(-350*time.Second))),
+			"R5": Revision("default", "R5", WithCreationTimestamp(now.Add(-300*time.Second))),
 		},
 		policy:      &pa,
+		clock:       timer,
 		want:        time.Duration(math.MaxInt32) * time.Second,
 		errExpected: false,
 	}, {
-		name:  "policy A, all Revisions in progress",
+		name:  "policy A, all Revisions in progress but must ignore R1",
 		route: Route("default", "test", withTraffic("spec", pair{"R1", 85}, pair{"R2", 8}, pair{"R3", 7})),
 		revMap: map[string]*v1.Revision{
-			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-24500*time.Millisecond))),
-			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-18*time.Second))),
-			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-12*time.Second))),
+			"R1": Revision("default", "R1", WithCreationTimestamp(now.Add(-24500*time.Millisecond))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(now.Add(-18500*time.Millisecond))),
+			"R3": Revision("default", "R3", WithCreationTimestamp(now.Add(-12500*time.Millisecond))),
 		},
 		policy:      &pa,
-		want:        time.Second,
+		clock:       timer,
+		want:        2 * time.Second,
 		errExpected: false,
 	}, {
 		name:  "policy A, at least one Revision is very old",
 		route: Route("default", "test", withTraffic("spec", pair{"R1", 85}, pair{"R2", 8}, pair{"R3", 7})),
 		revMap: map[string]*v1.Revision{
-			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-500*time.Second))),
-			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-18500*time.Millisecond))),
-			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-12*time.Second))),
+			"R1": Revision("default", "R1", WithCreationTimestamp(now.Add(-500*time.Second))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(now.Add(-18500*time.Millisecond))),
+			"R3": Revision("default", "R3", WithCreationTimestamp(now.Add(-12*time.Second))),
 		},
 		policy:      &pa,
+		clock:       timer,
 		want:        2 * time.Second,
 		errExpected: false,
 	}}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ans, e := timeTillNextEvent(tt.route, tt.revMap, tt.policy)
+			ans, e := timeTillNextEvent(tt.route, tt.revMap, tt.policy, tt.clock)
 			if ans != tt.want {
 				t.Errorf("wrong answer (got %v, want %v)", ans, tt.want)
 			}
@@ -168,12 +177,15 @@ func TestTimeTillNextEvent(t *testing.T) {
 }
 
 func TestModifyRouteSpec(t *testing.T) {
+	var now = time.Now()
+	var timer = clock.NewFakeClock(now)
 	var tests = []struct {
 		name        string
 		route       *v1.Route
 		revMap      map[string]*v1.Revision
 		newRevName  string
 		policy      *Policy
+		clock       clock.Clock
 		want        *v1.Route
 		errExpected bool
 	}{{
@@ -187,6 +199,7 @@ func TestModifyRouteSpec(t *testing.T) {
 		},
 		newRevName: "new",
 		policy:     &pa,
+		clock:      timer,
 		want: Route("default", "test", WithSpecTraffic(v1.TrafficTarget{
 			ConfigurationName: "new",
 			LatestRevision:    ptr.Bool(true),
@@ -197,12 +210,13 @@ func TestModifyRouteSpec(t *testing.T) {
 		name:  "newRevName is new, adds to an existing pool",
 		route: Route("default", "test", withTraffic("status", pair{"R1", 95}, pair{"R2", 5})),
 		revMap: map[string]*v1.Revision{
-			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-10000*time.Second))),
-			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-21*time.Second))),
-			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now())),
+			"R1": Revision("default", "R1", WithCreationTimestamp(now.Add(-10000*time.Second))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(now.Add(-21*time.Second))),
+			"R3": Revision("default", "R3", WithCreationTimestamp(now)),
 		},
 		newRevName: "R3",
 		policy:     &pa,
+		clock:      timer,
 		want: Route("default", "test", withTraffic("status", pair{"R1", 95}, pair{"R2", 5}),
 			withTraffic("spec", pair{"R1", 94}, pair{"R2", 5}, pair{"R3", 1})),
 		errExpected: false,
@@ -210,12 +224,13 @@ func TestModifyRouteSpec(t *testing.T) {
 		name:  "promotion, but pool size doesn't change",
 		route: Route("default", "test", withTraffic("status", pair{"R1", 94}, pair{"R2", 5}, pair{"R3", 1})),
 		revMap: map[string]*v1.Revision{
-			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-10000*time.Second))),
-			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-26*time.Second))),
-			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-2*time.Second))),
+			"R1": Revision("default", "R1", WithCreationTimestamp(now.Add(-10000*time.Second))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(now.Add(-26*time.Second))),
+			"R3": Revision("default", "R3", WithCreationTimestamp(now.Add(-2*time.Second))),
 		},
 		newRevName: "R3",
 		policy:     &pa,
+		clock:      timer,
 		want: Route("default", "test", withTraffic("status", pair{"R1", 94}, pair{"R2", 5}, pair{"R3", 1}),
 			withTraffic("spec", pair{"R1", 93}, pair{"R2", 6}, pair{"R3", 1})),
 		errExpected: false,
@@ -223,12 +238,13 @@ func TestModifyRouteSpec(t *testing.T) {
 		name:  "promotion, and pool size shrinks",
 		route: Route("default", "test", withTraffic("status", pair{"R1", 85}, pair{"R2", 8}, pair{"R3", 7})),
 		revMap: map[string]*v1.Revision{
-			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-10000*time.Second))),
-			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-41*time.Second))),
-			"R3": Revision("default", "R3", WithCreationTimestamp(time.Now().Add(-33*time.Second))),
+			"R1": Revision("default", "R1", WithCreationTimestamp(now.Add(-10000*time.Second))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(now.Add(-41*time.Second))),
+			"R3": Revision("default", "R3", WithCreationTimestamp(now.Add(-33*time.Second))),
 		},
 		newRevName: "R3",
 		policy:     &pa,
+		clock:      timer,
 		want: Route("default", "test", withTraffic("status", pair{"R1", 85}, pair{"R2", 8}, pair{"R3", 7}),
 			withTraffic("spec", pair{"R2", 93}, pair{"R3", 7})),
 		errExpected: false,
@@ -236,13 +252,12 @@ func TestModifyRouteSpec(t *testing.T) {
 		name:  "oldest revision always ignores progression/timer",
 		route: Route("default", "test", withTraffic("status", pair{"R1", 99}, pair{"R2", 1})),
 		revMap: map[string]*v1.Revision{
-			"R1": Revision("default", "R1", WithCreationTimestamp(time.Now().Add(-125*time.Second)),
-				WithRevisionLabel(RevisionGenerationKey, "1")),
-			"R2": Revision("default", "R2", WithCreationTimestamp(time.Now().Add(-61500*time.Millisecond)),
-				WithRevisionLabel(RevisionGenerationKey, "2")),
+			"R1": Revision("default", "R1", WithCreationTimestamp(now.Add(-125*time.Second))),
+			"R2": Revision("default", "R2", WithCreationTimestamp(now.Add(-61500*time.Millisecond))),
 		},
 		newRevName: "R2",
 		policy:     &policy,
+		clock:      timer,
 		want: Route("default", "test", withTraffic("status", pair{"R1", 99}, pair{"R2", 1}),
 			withTraffic("spec", pair{"R1", 90}, pair{"R2", 10})),
 		errExpected: false,
@@ -250,12 +265,47 @@ func TestModifyRouteSpec(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ans, e := modifyRouteSpec(tt.route, tt.revMap, tt.newRevName, tt.policy)
+			ans, e := modifyRouteSpec(tt.route, tt.revMap, tt.newRevName, tt.policy, tt.clock)
 			if diff := cmp.Diff(tt.want, ans); diff != "" {
 				t.Errorf("Route object is incorrect (-want, +got): %s", diff)
 			}
 			if (tt.errExpected && e == nil) || (!tt.errExpected && e != nil) {
 				t.Errorf("error output doesn't match")
+			}
+		})
+	}
+}
+
+func TestOldestRevision(t *testing.T) {
+	var now = time.Now()
+	var rev1 = Revision("default", "R1", WithCreationTimestamp(now.Add(-500*time.Second)))
+	var rev2 = Revision("default", "R2", WithCreationTimestamp(now.Add(200*time.Second)))
+	var rev3 = Revision("default", "R3", WithCreationTimestamp(now.Add(-100*time.Second)))
+	var rev4 = Revision("default", "R4", WithCreationTimestamp(now))
+	var tests = []struct {
+		name   string
+		revMap map[string]*v1.Revision
+		want   *v1.Revision
+	}{{
+		name: "simple test with 4 revisions",
+		revMap: map[string]*v1.Revision{
+			"R1": rev1,
+			"R2": rev2,
+			"R3": rev3,
+			"R4": rev4,
+		},
+		want: rev1,
+	}, {
+		name:   "empty map, return nil",
+		revMap: map[string]*v1.Revision{},
+		want:   nil,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ans := oldestRevision(tt.revMap)
+			if diff := cmp.Diff(tt.want, ans); diff != "" {
+				t.Errorf("wrong answer (-want, +got): %s", diff)
 			}
 		})
 	}

--- a/pkg/reconciler/delivery/policy.go
+++ b/pkg/reconciler/delivery/policy.go
@@ -104,6 +104,7 @@ func computeNewPercentExplicit(p *Policy, elapsed time.Duration) int {
 }
 
 // metricTillNextStage computes how much time (full seconds) to wait before progressing to the next stage
+// the returned result in full seconds MUST be STRICTLY bigger than the actual time to wait
 func metricTillNextStage(p *Policy, elapsed time.Duration) int {
 	// when no stages are specified, we assume that the final stage is reached immediately after initiation
 	if len(p.Stages) == 0 {
@@ -118,8 +119,13 @@ func metricTillNextStage(p *Policy, elapsed time.Duration) int {
 		}
 		metricCumulative += extra
 		if float64(metricCumulative) > metric {
-			return int(float64(metricCumulative)-metric) + 1 // +1 deals with float truncating
+			return nextBiggerInt(float64(metricCumulative) - metric)
 		}
 	}
 	return math.MaxInt32
+}
+
+// nextBiggerInt computes the next STRICTLY bigger int for a float64 number
+func nextBiggerInt(f float64) int {
+	return int(f) + 1
 }


### PR DESCRIPTION
This PR includes refactoring and some bug fixes:

(1) Using the K8s Clock interface to prevent test leaks.
(2) Determine which Revision should ignore progression/timer by comparing creation timestamps (instead of comparing Revision generation).