### PR TITLE
Allow KCD to access PolicyState informer; fix API group forbidden error

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -31,6 +31,8 @@ import (
 
 	defaultconfig "knative.dev/serving/pkg/apis/config"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
+
+	policystate "github.com/googleinterns/knative-continuous-delivery/pkg/client/injection/informers/delivery/v1alpha1/policystate"
 )
 
 var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
@@ -54,8 +56,9 @@ func newDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher
 		types,
 
 		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
-		func(ctx context.Context) context.Context {
-			return ctx
+		func(c context.Context) context.Context {
+			inf := policystate.Get(ctx)
+			return context.WithValue(c, policystate.Key{}, inf)
 		},
 
 		// Whether to disallow unknown fields.

--- a/config/100-cluster-role.yaml
+++ b/config/100-cluster-role.yaml
@@ -1,0 +1,11 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-delivery
+  labels:
+    serving.knative.dev/release: devel
+    serving.knative.dev/controller: "true"
+rules:
+  - apiGroups: ["delivery.knative.dev"]
+    resources: ["*", "*/status", "*/finalizers"]
+    verbs: ["get", "list", "create", "update", "delete", "deletecollection", "patch", "watch"]

--- a/pkg/apis/delivery/v1alpha1/policy_state_lifecycle.go
+++ b/pkg/apis/delivery/v1alpha1/policy_state_lifecycle.go
@@ -19,6 +19,9 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+// TODO: what conditions should be emitted in the Status?
+// - need to surface downstream dependency, Route in this case; need to know if Route is failing, or whatever
+//   - this makes a more friendly UX, easier for user to debug why their thing isn't working
 var policyStateCondSet = apis.NewLivingConditionSet()
 
 // GetConditionSet retrieves the condition set for this resource. Implements the KRShaped interface.

--- a/pkg/apis/delivery/v1alpha1/policy_state_types.go
+++ b/pkg/apis/delivery/v1alpha1/policy_state_types.go
@@ -23,17 +23,18 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// PolicyState is
+// PolicyState is used by KCD controller to communicate routing information to the
+// mutating webhook in order to sideline the Service reconciler
 type PolicyState struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Spec holds the desired state of the PolicyState (from the client).
+	// Spec holds info about what the routing state SHOULD be
 	// +optional
 	Spec PolicyStateSpec `json:"spec,omitempty"`
 
-	// Status communicates the observed state of the PolicyState (from the controller).
+	// Status holds info about what routing state has been written by the webhook
 	// +optional
 	Status PolicyStateStatus `json:"status,omitempty"`
 }
@@ -44,7 +45,8 @@ var (
 	_ duckv1.KRShaped = (*PolicyState)(nil)
 )
 
-// PolicyStateSpec holds the desired state of the PolicyState (from the client).
+// PolicyStateSpec holds the desired state of the PolicyState
+// Should be set by reconciler, and used by webhook to write Route appropriately
 type PolicyStateSpec struct {
 	// TODO: implement policy state spec
 }
@@ -56,7 +58,8 @@ type PolicyStateStatusFields struct {
 	// TODO: implement policy state status
 }
 
-// PolicyStateStatus communicates the observed state of the PolicyState (from the controller).
+// PolicyStateStatus communicates the observed state of the PolicyState
+// Should be set by the webhook
 type PolicyStateStatus struct {
 	duckv1.Status `json:",inline"`
 

--- a/pkg/reconciler/delivery/controller.go
+++ b/pkg/reconciler/delivery/controller.go
@@ -22,6 +22,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 
+	policystateinformer "github.com/googleinterns/knative-continuous-delivery/pkg/client/injection/informers/delivery/v1alpha1/policystate"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
 	routeinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/route"
@@ -44,12 +45,14 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	logger := logging.FromContext(ctx)
 	routeInformer := routeinformer.Get(ctx)
 	revisionInformer := revisioninformer.Get(ctx)
+	policystateInformer := policystateinformer.Get(ctx)
 
 	c := &Reconciler{
-		client:         servingclient.Get(ctx),
-		routeLister:    routeInformer.Lister(),
-		revisionLister: revisionInformer.Lister(),
-		clock:          clock.RealClock{},
+		client:            servingclient.Get(ctx),
+		routeLister:       routeInformer.Lister(),
+		revisionLister:    revisionInformer.Lister(),
+		policystateLister: policystateInformer.Lister(),
+		clock:             clock.RealClock{},
 	}
 	impl := configurationreconciler.NewImpl(ctx, c)
 	// a little hack that allows the reconciler to queue an event for future processing by itself

--- a/pkg/reconciler/delivery/delivery.go
+++ b/pkg/reconciler/delivery/delivery.go
@@ -24,6 +24,7 @@ import (
 	clientset "knative.dev/serving/pkg/client/clientset/versioned"
 	configurationreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/configuration"
 
+	v1alpha1 "github.com/googleinterns/knative-continuous-delivery/pkg/client/listers/delivery/v1alpha1"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/serving/pkg/apis/serving"
@@ -49,11 +50,12 @@ const (
 
 // Reconciler implements controller.Reconciler
 type Reconciler struct {
-	client         clientset.Interface
-	routeLister    listers.RouteLister
-	revisionLister listers.RevisionLister
-	followup       enqueueFunc
-	clock          clock.Clock
+	client            clientset.Interface
+	routeLister       listers.RouteLister
+	revisionLister    listers.RevisionLister
+	policystateLister v1alpha1.PolicyStateLister
+	followup          enqueueFunc
+	clock             clock.Clock
 }
 
 // private aliases for the types in Reconciler


### PR DESCRIPTION
This PR includes minor changes that allow KCD controller and webhook to query PolicyStates. In addition it fixes a small error that prevents the listing of PolicyState resource due to API group.