### PR TITLE
Crude proof-of-concept rollout that can circumvent Ksvc controller

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -32,6 +32,7 @@ import (
 	defaultconfig "knative.dev/serving/pkg/apis/config"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
+	deliveryclient "github.com/googleinterns/knative-continuous-delivery/pkg/client/injection/client"
 	policystate "github.com/googleinterns/knative-continuous-delivery/pkg/client/injection/informers/delivery/v1alpha1/policystate"
 )
 
@@ -58,7 +59,10 @@ func newDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher
 		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
 		func(c context.Context) context.Context {
 			inf := policystate.Get(ctx)
-			return context.WithValue(c, policystate.Key{}, inf)
+			clt := deliveryclient.Get(ctx)
+			c = context.WithValue(c, policystate.Key{}, inf)
+			c = context.WithValue(c, deliveryclient.Key{}, clt)
+			return c
 		},
 
 		// Whether to disallow unknown fields.

--- a/pkg/defaults/route_defaults_test.go
+++ b/pkg/defaults/route_defaults_test.go
@@ -1,0 +1,103 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaults
+
+import (
+	"context"
+	"testing"
+
+	"github.com/googleinterns/knative-continuous-delivery/pkg/apis/delivery/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/ptr"
+	"knative.dev/serving/pkg/apis/serving/v1"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCopyRouteSpec(t *testing.T) {
+	tests := []struct {
+		name string
+		ps   *v1alpha1.PolicyState
+		in   *ContinuousDeploymentRoute
+		want *ContinuousDeploymentRoute
+	}{{
+		name: "simple copy pasting of PolicyState spec",
+		ps: &v1alpha1.PolicyState{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.PolicyStateSpec{
+				Traffic: []v1.TrafficTarget{{
+					ConfigurationName: "test",
+					LatestRevision:    ptr.Bool(true),
+					Percent:           ptr.Int64(100),
+				}},
+			},
+		},
+		in: &ContinuousDeploymentRoute{v1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+		}},
+		want: &ContinuousDeploymentRoute{v1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+			Spec: v1.RouteSpec{
+				Traffic: []v1.TrafficTarget{{
+					ConfigurationName: "test",
+					LatestRevision:    ptr.Bool(true),
+					Percent:           ptr.Int64(100),
+				}},
+			},
+		}},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.in
+			got.copyRouteSpec(test.ps)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("ContinuousDeploymentRoute object is incorrect (-want, +got): %s", diff)
+			}
+		})
+	}
+}
+
+// we aren't implementing Validate but we still "test" it for the sake of consistency
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *ContinuousDeploymentRoute
+		want *apis.FieldError
+	}{{
+		name: "return nil directly (not doing validation)",
+		in:   &ContinuousDeploymentRoute{},
+		want: nil,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.in.Validate(context.Background())
+			if got != test.want {
+				t.Errorf("No error expected but got %v", got.Error())
+			}
+		})
+	}
+}

--- a/pkg/reconciler/delivery/controller.go
+++ b/pkg/reconciler/delivery/controller.go
@@ -22,6 +22,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 
+	deliveryclient "github.com/googleinterns/knative-continuous-delivery/pkg/client/injection/client"
 	policystateinformer "github.com/googleinterns/knative-continuous-delivery/pkg/client/injection/informers/delivery/v1alpha1/policystate"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
@@ -49,6 +50,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	c := &Reconciler{
 		client:            servingclient.Get(ctx),
+		psclient:          deliveryclient.Get(ctx),
 		routeLister:       routeInformer.Lister(),
 		revisionLister:    revisionInformer.Lister(),
 		policystateLister: policystateInformer.Lister(),

--- a/pkg/reconciler/delivery/resources/policystate.go
+++ b/pkg/reconciler/delivery/resources/policystate.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	v1alpha1 "github.com/googleinterns/knative-continuous-delivery/pkg/apis/delivery/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+)
+
+// MakePolicyState creates a PolicyState from a Configuration object
+func MakePolicyState(cfg *v1.Configuration) *v1alpha1.PolicyState {
+	return &v1alpha1.PolicyState{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfg.Name,
+			Namespace: cfg.Namespace,
+		},
+	}
+}

--- a/pkg/reconciler/testing/listers.go
+++ b/pkg/reconciler/testing/listers.go
@@ -15,6 +15,9 @@
 package testing
 
 import (
+	v1alpha1 "github.com/googleinterns/knative-continuous-delivery/pkg/apis/delivery/v1alpha1"
+	fakedeliveryclientset "github.com/googleinterns/knative-continuous-delivery/pkg/client/clientset/versioned/fake"
+	deliverylisters "github.com/googleinterns/knative-continuous-delivery/pkg/client/listers/delivery/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
@@ -27,6 +30,7 @@ import (
 var clientSetSchemes = []func(*runtime.Scheme) error{
 	fakekubeclientset.AddToScheme,
 	fakeservingclientset.AddToScheme,
+	fakedeliveryclientset.AddToScheme,
 }
 
 // Listers holds sorters
@@ -77,6 +81,11 @@ func (l *Listers) GetServingObjects() []runtime.Object {
 	return l.sorter.ObjectsForSchemeFunc(fakeservingclientset.AddToScheme)
 }
 
+// GetDeliveryObjects returns the delivery objects
+func (l *Listers) GetDeliveryObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(fakedeliveryclientset.AddToScheme)
+}
+
 // GetRouteLister returns the RouteLister
 func (l *Listers) GetRouteLister() servinglisters.RouteLister {
 	return servinglisters.NewRouteLister(l.IndexerFor(&v1.Route{}))
@@ -90,4 +99,9 @@ func (l *Listers) GetConfigurationLister() servinglisters.ConfigurationLister {
 // GetRevisionLister returns the RevisionLister
 func (l *Listers) GetRevisionLister() servinglisters.RevisionLister {
 	return servinglisters.NewRevisionLister(l.IndexerFor(&v1.Revision{}))
+}
+
+// GetPolicyStateLister returns the PolicyStateLister
+func (l *Listers) GetPolicyStateLister() deliverylisters.PolicyStateLister {
+	return deliverylisters.NewPolicyStateLister(l.IndexerFor(&v1alpha1.PolicyState{}))
 }

--- a/pkg/reconciler/testing/resources/helpers.go
+++ b/pkg/reconciler/testing/resources/helpers.go
@@ -1,0 +1,53 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	testingv1 "knative.dev/serving/pkg/testing/v1"
+)
+
+// Configuration creates a configuration with ConfigOptions
+func Configuration(namespace, name string, co ...testingv1.ConfigOption) *v1.Configuration {
+	c := &v1.Configuration{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+	for _, opt := range co {
+		opt(c)
+	}
+	c.SetDefaults(context.Background())
+	return c
+}
+
+// Revision creates a revision with RevisionOptions
+func Revision(namespace, name string, ro ...testingv1.RevisionOption) *v1.Revision {
+	r := &v1.Revision{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+	for _, opt := range ro {
+		opt(r)
+	}
+	r.SetDefaults(context.Background())
+	return r
+}

--- a/pkg/reconciler/testing/resources/policystate.go
+++ b/pkg/reconciler/testing/resources/policystate.go
@@ -1,0 +1,54 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	psv1alpha1 "github.com/googleinterns/knative-continuous-delivery/pkg/apis/delivery/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+)
+
+// PolicyStateOption enables further configuration of a PolicyState.
+type PolicyStateOption func(*psv1alpha1.PolicyState)
+
+// PolicyState returns a new PolicyState
+func PolicyState(namespace, name string, pso ...PolicyStateOption) *psv1alpha1.PolicyState {
+	ps := &psv1alpha1.PolicyState{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec:   psv1alpha1.PolicyStateSpec{},
+		Status: psv1alpha1.PolicyStateStatus{},
+	}
+	for _, opt := range pso {
+		opt(ps)
+	}
+	return ps
+}
+
+// WithPSSpecTraffic sets the spec traffic of a PolicyState
+func WithPSSpecTraffic(traffic ...v1.TrafficTarget) PolicyStateOption {
+	return func(ps *psv1alpha1.PolicyState) {
+		ps.Spec.Traffic = traffic
+	}
+}
+
+// WithPSStatusTraffic sets the status traffic of a PolicyState
+func WithPSStatusTraffic(traffic ...v1.TrafficTarget) PolicyStateOption {
+	return func(ps *psv1alpha1.PolicyState) {
+		ps.Status.Traffic = traffic
+	}
+}


### PR DESCRIPTION
Very crude and probably not very robust implementation for the PolicyState/webhook hack. It demonstrates the correct traffic splitting behavior when monitored with `kubectl get -w route <name> -o yaml`.