### PR TITLE
Refactoring & using NextUpdateTimestamp to handle interruptions

### DIFF
--- a/pkg/reconciler/delivery/table_test.go
+++ b/pkg/reconciler/delivery/table_test.go
@@ -83,7 +83,8 @@ func TestReconcile(t *testing.T) {
 			Object: Route("default", "test3", withTraffic(WithStatusTraffic, pair{"R1", 99}, pair{"R2", 1}),
 				withTraffic(WithSpecTraffic, pair{"R1", 90}, pair{"R2", 10})),
 		}, {
-			Object: PolicyState("default", "test3", withPSTraffic(WithPSSpecTraffic, pair{"R1", 90}, pair{"R2", 10})),
+			Object: PolicyState("default", "test3", withPSTraffic(WithPSSpecTraffic, pair{"R1", 90}, pair{"R2", 10}),
+				WithNextUpdateTimestamp(now.Add(59*time.Second))),
 		}},
 		PostConditions: []func(*testing.T, *TableRow){
 			assertEventQueued("default/test3", 59*time.Second),
@@ -115,7 +116,8 @@ func TestReconcile(t *testing.T) {
 				withTraffic(WithSpecTraffic, pair{"R2", 20}, pair{"R3", 20}, pair{"R4", 20}, pair{"R5", 20}, pair{"R6", 10}, pair{"R7", 10})),
 		}, {
 			Object: PolicyState("default", "test4",
-				withPSTraffic(WithPSSpecTraffic, pair{"R2", 20}, pair{"R3", 20}, pair{"R4", 20}, pair{"R5", 20}, pair{"R6", 10}, pair{"R7", 10})),
+				withPSTraffic(WithPSSpecTraffic, pair{"R2", 20}, pair{"R3", 20}, pair{"R4", 20}, pair{"R5", 20}, pair{"R6", 10}, pair{"R7", 10}),
+				WithNextUpdateTimestamp(now.Add(58*time.Second))),
 		}},
 		PostConditions: []func(*testing.T, *TableRow){
 			assertEventQueued("default/test4", 58*time.Second),

--- a/pkg/reconciler/testing/resources/policystate.go
+++ b/pkg/reconciler/testing/resources/policystate.go
@@ -15,6 +15,8 @@
 package resources
 
 import (
+	"time"
+
 	psv1alpha1 "github.com/googleinterns/knative-continuous-delivery/pkg/apis/delivery/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -50,5 +52,12 @@ func WithPSSpecTraffic(traffic ...v1.TrafficTarget) PolicyStateOption {
 func WithPSStatusTraffic(traffic ...v1.TrafficTarget) PolicyStateOption {
 	return func(ps *psv1alpha1.PolicyState) {
 		ps.Status.Traffic = traffic
+	}
+}
+
+// WithNextUpdateTimestamp sets the Status.NextUpdateTimestamp of a PolicyState
+func WithNextUpdateTimestamp(t time.Time) PolicyStateOption {
+	return func(ps *psv1alpha1.PolicyState) {
+		ps.Status.NextUpdateTimestamp = &metav1.Time{t}
 	}
 }


### PR DESCRIPTION
Included in this PR:

- Some code refactoring to improve the readability of `updateRoute` in `delivery.go`
- Make use of `NextUpdateTimestamp` field in `PolicyState` to address KCD controller interruptions
- Update test cases