### PR TITLE
Slight refactoring of modifyRouteSpec

### DIFF
--- a/pkg/reconciler/delivery/delivery_test.go
+++ b/pkg/reconciler/delivery/delivery_test.go
@@ -179,6 +179,39 @@ func TestTimeTillNextEvent(t *testing.T) {
 	}
 }
 
+func TestIsNameListed(t *testing.T) {
+	var tests = []struct {
+		name       string
+		route      *v1.Route
+		newRevName string
+		want       bool
+	}{{
+		name:       "list does not contain newRevName",
+		route:      Route("default", "test", withTraffic(WithStatusTraffic, pair{"R1", 95}, pair{"R2", 5})),
+		newRevName: "R3",
+		want:       false,
+	}, {
+		name:       "list contains newRevName",
+		route:      Route("default", "test", withTraffic(WithStatusTraffic, pair{"R1", 95}, pair{"R2", 5})),
+		newRevName: "R2",
+		want:       true,
+	}, {
+		name:       "list is empty",
+		route:      Route("default", "test"),
+		newRevName: "DNE",
+		want:       false,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ans := isNameListed(test.route, test.newRevName)
+			if ans != test.want {
+				t.Errorf("wrong answer (got %v, want %v)", ans, test.want)
+			}
+		})
+	}
+}
+
 func TestModifyRouteSpec(t *testing.T) {
 	var now = time.Now()
 	var timer = clock.NewFakeClock(now)


### PR DESCRIPTION
Factored out a small piece of logic out of `modifyRouteSpec`, wrote unit tests for it, and updated the comments preceding `modifyRouteSpec`.

I could have factored out other chunks as well but they are much more involved (needs to return error, etc.) which makes the extracted helper functions have ugly interfaces (and more difficult to test), so I decided against it.